### PR TITLE
Add basic turn conversation claim handling

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ mypy==0.770
 pytest==5.4.2
 pytest-cov==2.9.0
 coveralls==2.0.0
+pytest-asyncio==0.12.0
+pytest-sanic==1.6.1

--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -135,6 +135,7 @@ class TurnInputTests(TestCase):
                     }
                 ]
             },
+            headers={"X-Turn-Claim": "conversation-claim"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json, {"success": True})
@@ -146,6 +147,9 @@ class TurnInputTests(TestCase):
         self.assertEqual(message.sender_id, "27820001001")
         self.assertEqual(message.message_id, "message-id")
         self.assertEqual(message.metadata, {"timestamp": "1518694235", "type": "text"})
+        self.assertEqual(
+            message.output_channel.conversation_claim, "conversation-claim"
+        )
 
     def test_webhook_handle_invalid_messages(self):
         """

--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -502,3 +502,24 @@ async def test_send_text_message(turn_mock_server: Sanic):
     }
     assert message.headers["Authorization"] == "Bearer testtoken"
     assert message.headers["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_send_image_message(turn_mock_server: Sanic):
+    """
+    Makes an HTTP request to Turn to send the message
+    """
+    output_channel = TurnOutput(
+        url=f"http://{turn_mock_server.host}:{turn_mock_server.port}", token="testtoken"
+    )
+    await output_channel.send_response(
+        "27820001001", {"image": "https://example.org/image.jpg"}
+    )
+    [message] = turn_mock_server.app.messages
+    assert message.json == {
+        "to": "27820001001",
+        "type": "image",
+        "image": {"link": "https://example.org/image.jpg"},
+    }
+    assert message.headers["Authorization"] == "Bearer testtoken"
+    assert message.headers["Content-Type"] == "application/json"

--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -1,8 +1,11 @@
 from unittest import TestCase, mock
 
+import pytest
 from rasa.core import run, utils
+from sanic import Sanic
+from sanic.response import json
 
-from turn_rasa_connector.turn import TurnInput
+from turn_rasa_connector.turn import TurnInput, TurnOutput
 
 
 class TurnInputTests(TestCase):
@@ -10,15 +13,21 @@ class TurnInputTests(TestCase):
         self.input_channel = self._create_input_channel()
         self.app = run.configure_app([self.input_channel])
 
-    def _create_input_channel(self, hmac_secret=None):
-        return TurnInput(hmac_secret=hmac_secret)
+    def _create_input_channel(
+        self, hmac_secret=None, url="https://turn", token="testtoken"
+    ):
+        return TurnInput(hmac_secret=hmac_secret, url=url, token=token)
 
     def test_from_credentials(self):
         """
         Stores the credentials on the class
         """
-        instance = TurnInput.from_credentials({"hmac_secret": "test-secret"})
+        instance = TurnInput.from_credentials(
+            {"hmac_secret": "test-secret", "url": "https://turn", "token": "testtoken"}
+        )
         self.assertEqual(instance.hmac_secret, "test-secret")
+        self.assertEqual(instance.url, "https://turn")
+        self.assertEqual(instance.token, "testtoken")
 
     def test_no_credentials(self):
         """
@@ -453,3 +462,43 @@ class TurnInputTests(TestCase):
                 "type": "location",
             },
         )
+
+
+def test_output_channel_name():
+    """
+    Test that the output channel's name is correct
+    """
+    output_channel = TurnOutput(url="https://turn", token="testtoken")
+    assert output_channel.name() == "turn"
+
+
+@pytest.fixture
+def turn_mock_server(loop, test_client):
+    app = Sanic("mock_turn")
+    app.messages = []
+
+    @app.route("/v1/messages", methods=["POST"])
+    async def messages(request):
+        app.messages.append(request)
+        return json({})
+
+    return loop.run_until_complete(test_client(app))
+
+
+@pytest.mark.asyncio
+async def test_send_text_message(turn_mock_server: Sanic):
+    """
+    Makes an HTTP request to Turn to send the message
+    """
+    output_channel = TurnOutput(
+        url=f"http://{turn_mock_server.host}:{turn_mock_server.port}", token="testtoken"
+    )
+    await output_channel.send_response("27820001001", {"text": "test message"})
+    [message] = turn_mock_server.app.messages
+    assert message.json == {
+        "to": "27820001001",
+        "type": "text",
+        "text": {"body": "test message"},
+    }
+    assert message.headers["Authorization"] == "Bearer testtoken"
+    assert message.headers["Content-Type"] == "application/json"

--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -545,3 +545,24 @@ async def test_send_text_with_buttons_message(turn_mock_server: Sanic):
     }
     assert message.headers["Authorization"] == "Bearer testtoken"
     assert message.headers["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_send_custom_message(turn_mock_server: Sanic):
+    """
+    Makes an HTTP request to Turn to send the message
+    """
+    output_channel = TurnOutput(
+        url=f"http://{turn_mock_server.host}:{turn_mock_server.port}", token="testtoken"
+    )
+    await output_channel.send_response(
+        "27820001001", {"custom": {"type": "text", "text": {"body": "test message"}}},
+    )
+    [message] = turn_mock_server.app.messages
+    assert message.json == {
+        "to": "27820001001",
+        "type": "text",
+        "text": {"body": "test message"},
+    }
+    assert message.headers["Authorization"] == "Bearer testtoken"
+    assert message.headers["Content-Type"] == "application/json"

--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -523,3 +523,25 @@ async def test_send_image_message(turn_mock_server: Sanic):
     }
     assert message.headers["Authorization"] == "Bearer testtoken"
     assert message.headers["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_send_text_with_buttons_message(turn_mock_server: Sanic):
+    """
+    Makes an HTTP request to Turn to send the message
+    """
+    output_channel = TurnOutput(
+        url=f"http://{turn_mock_server.host}:{turn_mock_server.port}", token="testtoken"
+    )
+    await output_channel.send_response(
+        "27820001001",
+        {"text": "test message", "buttons": [{"title": "item1"}, {"title": "item2"}]},
+    )
+    [message] = turn_mock_server.app.messages
+    assert message.json == {
+        "to": "27820001001",
+        "type": "text",
+        "text": {"body": "test message\n1: item1\n2: item2"},
+    }
+    assert message.headers["Authorization"] == "Bearer testtoken"
+    assert message.headers["Content-Type"] == "application/json"

--- a/turn_rasa_connector/turn.py
+++ b/turn_rasa_connector/turn.py
@@ -3,10 +3,11 @@ import hmac
 import json
 import logging
 from asyncio import wait
-from typing import Any, Awaitable, Callable, Dict, Optional, Text
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Text
 from urllib.parse import urljoin
 
 import httpx
+from rasa.cli import utils as cli_utils
 from rasa.core.channels import InputChannel, OutputChannel, UserMessage
 from sanic import Blueprint, response
 from sanic.request import Request
@@ -51,6 +52,18 @@ class TurnOutput(OutputChannel):
         await self._send_message(
             {"to": recipient_id, "type": "image", "image": {"link": image}}
         )
+
+    async def send_text_with_buttons(
+        self,
+        recipient_id: Text,
+        text: Text,
+        buttons: List[Dict[Text, Any]],
+        **kwargs: Any,
+    ) -> None:
+        for idx, button in enumerate(buttons):
+            text += "\n"
+            text += cli_utils.button_to_string(button, idx)
+        await self.send_text_message(recipient_id, text, **kwargs)
 
 
 class TurnInput(InputChannel):

--- a/turn_rasa_connector/turn.py
+++ b/turn_rasa_connector/turn.py
@@ -25,9 +25,12 @@ class TurnOutput(OutputChannel):
     def name(cls) -> Text:
         return "turn"
 
-    def __init__(self, url: Text, token: Text):
+    def __init__(
+        self, url: Text, token: Text, conversation_claim: Optional[Text] = None
+    ):
         self.url = url
         self.token = token
+        self.conversation_claim = conversation_claim
         super().__init__()
 
     async def _send_message(self, body: dict):
@@ -131,9 +134,12 @@ class TurnInput(InputChannel):
                     {"success": False, "error": "invalid_body"}, status=400
                 )
 
+            conversation_claim = request.headers.get("X-Turn-Claim", None)
+
             user_messages = []
             for message in messages:
                 try:
+                    message["conversation_claim"] = conversation_claim
                     user_messages.append(self.extract_message(message))
                 except (TypeError, KeyError, AttributeError):
                     logger.warning(f"Invalid message: {json.dumps(message)}")
@@ -161,7 +167,9 @@ class TurnInput(InputChannel):
     def handle_common(self, text: Optional[str], message: dict) -> UserMessage:
         return UserMessage(
             text=text,
-            output_channel=self.get_output_channel(),
+            output_channel=self.get_output_channel(
+                message.pop("conversation_claim", None)
+            ),
             sender_id=message.pop("from"),
             input_channel=self.name(),
             message_id=message.pop("id"),
@@ -195,5 +203,7 @@ class TurnInput(InputChannel):
     def handle_location(self, message: dict) -> UserMessage:
         return self.handle_common(None, message)
 
-    def get_output_channel(self) -> OutputChannel:
-        return TurnOutput(self.url, self.token)
+    def get_output_channel(
+        self, conversation_claim: Optional[Text] = None
+    ) -> OutputChannel:
+        return TurnOutput(self.url, self.token, conversation_claim)

--- a/turn_rasa_connector/turn.py
+++ b/turn_rasa_connector/turn.py
@@ -34,11 +34,13 @@ class TurnOutput(OutputChannel):
         super().__init__()
 
     async def _send_message(self, body: dict):
-        # TODO: Turn conversation claim handling
+        headers = {"Authorization": f"Bearer {self.token}"}
+        if self.conversation_claim:
+            # TODO: End conversation claim at end of session
+            headers["X-Turn-Claim-Extend"] = self.conversation_claim
+
         result = await httpx.post(
-            urljoin(self.url, "/v1/messages"),
-            headers={"Authorization": f"Bearer {self.token}"},
-            json=body,
+            urljoin(self.url, "/v1/messages"), headers=headers, json=body,
         )
         # TODO: Retries and error handling
         result.raise_for_status()

--- a/turn_rasa_connector/turn.py
+++ b/turn_rasa_connector/turn.py
@@ -31,11 +31,13 @@ class TurnOutput(OutputChannel):
         super().__init__()
 
     async def _send_message(self, body: dict):
+        # TODO: Turn conversation claim handling
         result = await httpx.post(
             urljoin(self.url, "/v1/messages"),
             headers={"Authorization": f"Bearer {self.token}"},
             json=body,
         )
+        # TODO: Retries and error handling
         result.raise_for_status()
 
     async def send_text_message(
@@ -64,6 +66,15 @@ class TurnOutput(OutputChannel):
             text += "\n"
             text += cli_utils.button_to_string(button, idx)
         await self.send_text_message(recipient_id, text, **kwargs)
+
+    async def send_custom_json(
+        self, recipient_id: Text, json_message: Dict[Text, Any], **kwargs: Any
+    ) -> None:
+        json_message["to"] = recipient_id
+        await self._send_message(json_message)
+
+    # TODO: elements message type
+    # TODO: attachment message type
 
 
 class TurnInput(InputChannel):

--- a/turn_rasa_connector/turn.py
+++ b/turn_rasa_connector/turn.py
@@ -29,15 +29,28 @@ class TurnOutput(OutputChannel):
         self.token = token
         super().__init__()
 
-    async def send_text_message(
-        self, recipient_id: Text, text: Text, **kwargs: Any
-    ) -> None:
+    async def _send_message(self, body: dict):
         result = await httpx.post(
             urljoin(self.url, "/v1/messages"),
             headers={"Authorization": f"Bearer {self.token}"},
-            json={"to": recipient_id, "type": "text", "text": {"body": text}},
+            json=body,
         )
         result.raise_for_status()
+
+    async def send_text_message(
+        self, recipient_id: Text, text: Text, **kwargs: Any
+    ) -> None:
+        await self._send_message(
+            {"to": recipient_id, "type": "text", "text": {"body": text}}
+        )
+
+    async def send_image_url(
+        self, recipient_id: Text, image: Text, **kwargs: Any
+    ) -> None:
+        # TODO: Use media ID instead of image URL
+        await self._send_message(
+            {"to": recipient_id, "type": "image", "image": {"link": image}}
+        )
 
 
 class TurnInput(InputChannel):


### PR DESCRIPTION
This will extend the turn conversation claims on the reply, if the webhook had a claim attached to it.

I'll add the ability to end a conversation claim once we know what that looks like from the bot side of things