### PR TITLE
Ensure message.text is a string

### DIFF
--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -173,7 +173,7 @@ class TurnInputTests(TestCase):
                 "type": "audio",
             }
         )
-        self.assertEqual(message.text, None)
+        self.assertEqual(message.text, "")
         self.assertEqual(message.sender_id, "27820001001")
         self.assertEqual(message.message_id, "ABGGFlA5FpafAgo6tHcNmNjXmuSf")
         self.assertEqual(
@@ -316,7 +316,7 @@ class TurnInputTests(TestCase):
                 },
             }
         )
-        self.assertEqual(message.text, None)
+        self.assertEqual(message.text, "")
         self.assertEqual(message.sender_id, "27820001001")
         self.assertEqual(message.message_id, "ABGGFlA5FpafAgo6tHcNmNjXmuSf")
         self.assertEqual(
@@ -379,7 +379,7 @@ class TurnInputTests(TestCase):
                 "type": "contacts",
             }
         )
-        self.assertEqual(message.text, None)
+        self.assertEqual(message.text, "")
         self.assertEqual(message.sender_id, "16505551234")
         self.assertEqual(message.message_id, "ABGGFlA4dSRvAgo6C4Z53hMh1ugR")
         self.assertEqual(
@@ -443,7 +443,7 @@ class TurnInputTests(TestCase):
                 "type": "location",
             }
         )
-        self.assertEqual(message.text, None)
+        self.assertEqual(message.text, "")
         self.assertEqual(message.sender_id, "16315551234")
         self.assertEqual(message.message_id, "ABGGFlA5FpafAgo6tHcNmNjXmuSf")
         self.assertEqual(

--- a/turn_rasa_connector/turn.py
+++ b/turn_rasa_connector/turn.py
@@ -187,7 +187,7 @@ class TurnInput(InputChannel):
         handler = getattr(self, f"handle_{message_type}")
         return handler(message)
 
-    def handle_common(self, text: Optional[str], message: dict) -> UserMessage:
+    def handle_common(self, text: Text, message: dict) -> UserMessage:
         return UserMessage(
             text=text,
             output_channel=self.get_output_channel(
@@ -203,7 +203,7 @@ class TurnInput(InputChannel):
         return self.handle_common(message.pop("text")["body"], message)
 
     def handle_media(self, media_type: str, message: dict) -> UserMessage:
-        return self.handle_common(message[media_type].pop("caption", None), message)
+        return self.handle_common(message[media_type].pop("caption", ""), message)
 
     def handle_audio(self, message: dict) -> UserMessage:
         return self.handle_media("audio", message)
@@ -221,10 +221,10 @@ class TurnInput(InputChannel):
         return self.handle_media("voice", message)
 
     def handle_contacts(self, message: dict) -> UserMessage:
-        return self.handle_common(None, message)
+        return self.handle_common("", message)
 
     def handle_location(self, message: dict) -> UserMessage:
-        return self.handle_common(None, message)
+        return self.handle_common("", message)
 
     def get_output_channel(
         self, conversation_claim: Optional[Text] = None


### PR DESCRIPTION
Rasa assumes that `message.text` is a string, so we should always set it to a string.

https://github.com/RasaHQ/rasa/blob/master/rasa/core/processor.py#L453-L475