### PR TITLE
Message deduplication

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,13 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependancies
       run: |
         pip install -r requirements.txt
@@ -53,6 +60,13 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependancies
       run: |
         pip install -r requirements.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      TEST_POSTGRES_URL: postgres://postgres:postgres
+      TEST_POSTGRES_URL: postgres://postgres:postgres@localhost
     strategy:
       matrix:
         python-version: [3.6, 3.7]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,20 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      TEST_POSTGRES_URL: postgres://postgres:postgres
     strategy:
       matrix:
         python-version: [3.6, 3.7]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ A Rasa Connector for https://www.turn.io/
 
 Handles Turn conversation claims
 
+## Configuration
+This connector has the following configuration:
+
+url (required) - The URL of the Turn instance
+
+token (required) - The authorization token to use when making requests to Turn
+
+hmac_secret (optional) - If specified, validates that the HMAC signature in the webhook request is valid, returning an HTTP 401 if invalid
+
+postgresql_url (optional) - If using PostgreSQL as a tracker store, ignores messages with message IDs that we've already processed (deduplication)
+
+Example:
+```yaml
+turn_rasa_connector.turn.TurnInput:
+  url: "https://whatsapp.turn.io"
+  token: "xxxxxxxxxxx"
+  hmac_secret: "xxxx-xxxx-xxxx"
+  postgresql_url: "postgres://
+```
+
 ## Development
 ```bash
 ~ pip install -r requirements.txt -r requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ hmac_secret (optional) - If specified, validates that the HMAC signature in the 
 
 postgresql_url (optional) - If using PostgreSQL as a tracker store, ignores messages with message IDs that we've already processed (deduplication)
 
-Example:
+Example credentials.yml:
 ```yaml
 turn_rasa_connector.turn.TurnInput:
   url: "https://whatsapp.turn.io"
@@ -27,6 +27,8 @@ turn_rasa_connector.turn.TurnInput:
 ```
 
 ## Development
+Requires PostgreSQL. PostgreSQL location controlled using the TEST_POSTGRES_URL environment variable, defaulting to `postgres://`
+
 ```bash
 ~ pip install -r requirements.txt -r requirements-dev.txt
 ~ black .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 rasa==1.10.2
 async_lru==1.0.2
+asyncpg==0.20.1

--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import os
 import time
-from contextlib import asynccontextmanager
 from unittest import TestCase, mock
 from unittest.mock import Mock
 
@@ -714,13 +713,16 @@ async def test_message_processed():
     )
 
     # We need a fake pool, so that we can keep everything in our transaction
-    @asynccontextmanager
-    async def fake_pool():
-        yield conn
+    class FakePool:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            pass
 
     async def fake_get_postgresql_pool():
         pool = Mock()
-        pool.acquire = fake_pool
+        pool.acquire = FakePool
         return pool
 
     input_channel = TurnInput(None, None, None, None)

--- a/turn_rasa_connector/turn.py
+++ b/turn_rasa_connector/turn.py
@@ -3,13 +3,16 @@ import hmac
 import json
 import logging
 from asyncio import wait
+from datetime import datetime, timedelta
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Text
 from urllib.parse import urljoin
 
+import asyncpg
 import httpx
 from async_lru import alru_cache
 from rasa.cli import utils as cli_utils
 from rasa.core.channels import InputChannel, OutputChannel, UserMessage
+from rasa.core.events import UserUttered
 from sanic import Blueprint, response
 from sanic.request import Request
 from sanic.response import HTTPResponse
@@ -136,13 +139,57 @@ class TurnInput(InputChannel):
             cls.raise_missing_credentials_exception()
 
         return cls(
-            credentials.get("hmac_secret"), credentials["url"], credentials["token"]
+            credentials.get("hmac_secret"),
+            credentials["url"],
+            credentials["token"],
+            credentials.get("postgresql_url"),
         )
 
-    def __init__(self, hmac_secret: Optional[Text], url: Text, token: Text) -> None:
+    def __init__(
+        self,
+        hmac_secret: Optional[Text],
+        url: Text,
+        token: Text,
+        postgresql_url: Optional[Text],
+    ) -> None:
         self.hmac_secret = hmac_secret
         self.url = url
         self.token = token
+        self.postgresql_url = postgresql_url
+        self._postgresql_pool = None
+
+    async def get_postgresql_pool(self) -> Optional[asyncpg.pool.Pool]:
+        if self._postgresql_pool is None and self.postgresql_url is not None:
+            self._postgresql_pool = await asyncpg.create_pool(self.postgresql_url)
+        return self._postgresql_pool
+
+    async def message_processed(self, sender_id: Text, message_id: Text) -> bool:
+        """
+        Have we processed a message with this ID before
+        """
+        pool = await self.get_postgresql_pool()
+        if pool is None:
+            # If we don't have a postgresql config, don't deduplicate
+            return False
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                result = await connection.fetchval(
+                    """
+                    SELECT 1
+                    FROM events
+                    WHERE
+                        sender_id = $1 AND
+                        type_name = $2 AND
+                        data::json ->> 'message_id' = $3 AND
+                        timestamp > $4
+                    LIMIT 1
+                    """,
+                    sender_id,
+                    UserUttered.type_name,
+                    message_id,
+                    (datetime.utcnow() - timedelta(days=1)).timestamp(),
+                )
+                return result == 1
 
     def blueprint(
         self, on_new_message: Callable[[UserMessage], Awaitable[Any]]


### PR DESCRIPTION
Sometimes Turn sends us the same message multiple times.

This will allow us, if we're using postgresql as our tracker store, to not process messages that we have already processed.