### PR TITLE
Add the ability to release the conversation claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ turn_rasa_connector.turn.TurnInput:
 This connector will handle receiving and extending the Turn conversation claim with
 every message reply.
 
-This is controlled by the `session` key on the message:
-- `extend` - This is the default if no session key is supplied. Will extend the conversation claim.
+This is controlled by the `claim` key on the message:
+- `extend` - This is the default if no claim key is supplied. Will extend the conversation claim.
 - `release` - Will release the conversation claim.
 
 Example:
 ```yaml
 utter_continue:
   - text: "What would you like to do?"
-  # session: extend
+  # claim: extend
   # Is the default
 
 utter_end:
-  - text: "Thank you! Your session will now end"
-    session: release
+  - text: "Thank you! Your conversation claim will now end"
+    claim: release
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ turn_rasa_connector.turn.TurnInput:
   http_retries: 3
 ```
 
+## Conversation Claims
+This connector will handle receiving and extending the Turn conversation claim with
+every message reply.
+
+This is controlled by the `session` key on the message:
+- `extend` - This is the default if no session key is supplied. Will extend the conversation claim.
+- `release` - Will release the conversation claim.
+
+Example:
+```yaml
+utter_continue:
+  - text: "What would you like to do?"
+  # session: extend
+  # Is the default
+
+utter_end:
+  - text: "Thank you! Your session will now end"
+    session: release
+```
+
 ## Development
 Requires PostgreSQL. PostgreSQL location controlled using the TEST_POSTGRES_URL environment variable, defaulting to `postgres://`
 

--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -596,7 +596,7 @@ async def test_send_text_message_failure(turn_mock_server: Sanic):
 
 
 @pytest.mark.asyncio
-async def test_convesation_claim(turn_mock_server: Sanic):
+async def test_conversation_claim(turn_mock_server: Sanic):
     """
     Extends the conversation claim if possible
     """
@@ -608,6 +608,23 @@ async def test_convesation_claim(turn_mock_server: Sanic):
     await output_channel.send_response("27820001001", {"text": "test message"})
     [message] = turn_mock_server.app.messages
     assert message.headers["X-Turn-Claim-Extend"] == "conversation-claim-id"
+
+
+@pytest.mark.asyncio
+async def test_release_conversation_claim(turn_mock_server: Sanic):
+    """
+    Releases the conversation claim if requested and possible
+    """
+    output_channel = TurnOutput(
+        url=f"http://{turn_mock_server.host}:{turn_mock_server.port}",
+        token="testtoken",
+        conversation_claim="conversation-claim-id",
+    )
+    await output_channel.send_response(
+        "27820001001", {"text": "test message", "session": "release"}
+    )
+    [message] = turn_mock_server.app.messages
+    assert message.headers["X-Turn-Claim-Release"] == "conversation-claim-id"
 
 
 @pytest.mark.asyncio

--- a/turn_rasa_connector/test_turn.py
+++ b/turn_rasa_connector/test_turn.py
@@ -621,7 +621,7 @@ async def test_release_conversation_claim(turn_mock_server: Sanic):
         conversation_claim="conversation-claim-id",
     )
     await output_channel.send_response(
-        "27820001001", {"text": "test message", "session": "release"}
+        "27820001001", {"text": "test message", "claim": "release"}
     )
     [message] = turn_mock_server.app.messages
     assert message.headers["X-Turn-Claim-Release"] == "conversation-claim-id"

--- a/turn_rasa_connector/turn.py
+++ b/turn_rasa_connector/turn.py
@@ -66,13 +66,13 @@ class TurnOutput(OutputChannel):
         super().__init__()
 
     async def _send_message(
-        self, body: dict, session: Optional[Text] = "extend", **kwargs
+        self, body: dict, claim: Optional[Text] = "extend", **kwargs
     ) -> None:
         headers = {"Authorization": f"Bearer {self.token}"}
         if self.conversation_claim:
-            if session == "extend":
+            if claim == "extend":
                 headers["X-Turn-Claim-Extend"] = self.conversation_claim
-            elif session == "release":
+            elif claim == "release":
                 headers["X-Turn-Claim-Release"] = self.conversation_claim
 
         for i in range(self.http_retries):


### PR DESCRIPTION
This will allow us to specify a `claim` on the message, which will allow us to set whether a message will extend or release a conversation claim.

We can set the final messages in our bot to `release` the `claim`, so that they can go back to the main system when the bot has finished.