### PR TITLE
Add tools and guide for benchmarking

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,20 @@
+Running Benchmarks
+------------------
+You'll need an actual Rasa bot to run the benchmarks against.
+
+Add something similar to this in `credentials.yaml`
+```yaml
+turn_rasa_connector.turn.TurnInput:
+  url: "http://localhost:8080"
+  token: "test-token"
+```
+
+And then you can run the mock turn server:
+```bash
+python benchmark/fake_turn.py
+```
+
+You can then use a tool like [vegeta](https://github.com/tsenart/vegeta) to make requests to test how much load the bot will be able to handle:
+```bash
+jq -ncM 'while(true; .+1) | {method: "POST", url: "http://:5005/webhooks/turn/webhook/", body: {messages: [{from: ( . | tostring ) , text: { body: "check" }, id: ( . | tostring ), type: "text"}]} | @base64 }' | vegeta attack -rate=10/s -format=json -duration=600s --max-connections=500 -lazy | tee results.bin | vegeta report
+```

--- a/benchmark/fake_turn.py
+++ b/benchmark/fake_turn.py
@@ -7,22 +7,25 @@ from sanic.response import json
 
 app = Sanic("fake_turn")
 
+MINIMUM_LATENCY = 0.05
+MAXIMUM_LATENCY = 0.5
+
 
 @app.post("/v1/messages")
 async def create_message(request):
-    await asyncio.sleep(random.uniform(0.05, 0.5))
+    await asyncio.sleep(random.uniform(MINIMUM_LATENCY, MAXIMUM_LATENCY))
     return json({"messages": [{"id": uuid4().hex}]}, status=201)
 
 
 @app.post("/v1/media")
 async def create_media(request):
-    await asyncio.sleep(random.uniform(0.05, 0.5))
+    await asyncio.sleep(random.uniform(MINIMUM_LATENCY, MAXIMUM_LATENCY))
     return json({"media": [{"id": uuid4().hex}]}, status=201)
 
 
 @app.post("v1/messages/<message_id>/automation")
 async def rerun_automation(request, message_id):
-    await asyncio.sleep(random.uniform(0.05, 0.5))
+    await asyncio.sleep(random.uniform(MINIMUM_LATENCY, MAXIMUM_LATENCY))
     return json({}, status=201)
 
 

--- a/benchmark/fake_turn.py
+++ b/benchmark/fake_turn.py
@@ -1,0 +1,30 @@
+import asyncio
+import random
+from uuid import uuid4
+
+from sanic import Sanic
+from sanic.response import json
+
+app = Sanic("fake_turn")
+
+
+@app.post("/v1/messages")
+async def create_message(request):
+    await asyncio.sleep(random.uniform(0.05, 0.5))
+    return json({"messages": [{"id": uuid4().hex}]}, status=201)
+
+
+@app.post("/v1/media")
+async def create_media(request):
+    await asyncio.sleep(random.uniform(0.05, 0.5))
+    return json({"media": [{"id": uuid4().hex}]}, status=201)
+
+
+@app.post("v1/messages/<message_id>/automation")
+async def rerun_automation(request, message_id):
+    await asyncio.sleep(random.uniform(0.05, 0.5))
+    return json({}, status=201)
+
+
+if __name__ == "__main__":
+    app.run(port=8080)

--- a/benchmark/test_fake_turn.py
+++ b/benchmark/test_fake_turn.py
@@ -1,0 +1,34 @@
+import time
+
+import pytest
+
+from .fake_turn import app
+
+
+@pytest.mark.asyncio
+async def test_create_message():
+    start = time.time()
+    request, response = await app.asgi_client.post("/v1/messages")
+    assert time.time() - start > 0.05
+    assert response.status == 201
+    assert response.json()["messages"][0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_create_media():
+    start = time.time()
+    request, response = await app.asgi_client.post("/v1/media")
+    assert time.time() - start > 0.05
+    assert response.status == 201
+    assert response.json()["media"][0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_rerun_automation():
+    start = time.time()
+    request, response = await app.asgi_client.post(
+        "/v1/messages/test-message-id/automation"
+    )
+    assert time.time() - start > 0.05
+    assert response.status == 201
+    assert response.json() == {}

--- a/benchmark/test_fake_turn.py
+++ b/benchmark/test_fake_turn.py
@@ -2,14 +2,14 @@ import time
 
 import pytest
 
-from .fake_turn import app
+from .fake_turn import MINIMUM_LATENCY, app
 
 
 @pytest.mark.asyncio
 async def test_create_message():
     start = time.time()
     request, response = await app.asgi_client.post("/v1/messages")
-    assert time.time() - start > 0.05
+    assert time.time() - start > MINIMUM_LATENCY
     assert response.status == 201
     assert response.json()["messages"][0]["id"]
 
@@ -18,7 +18,7 @@ async def test_create_message():
 async def test_create_media():
     start = time.time()
     request, response = await app.asgi_client.post("/v1/media")
-    assert time.time() - start > 0.05
+    assert time.time() - start > MINIMUM_LATENCY
     assert response.status == 201
     assert response.json()["media"][0]["id"]
 
@@ -29,6 +29,6 @@ async def test_rerun_automation():
     request, response = await app.asgi_client.post(
         "/v1/messages/test-message-id/automation"
     )
-    assert time.time() - start > 0.05
+    assert time.time() - start > MINIMUM_LATENCY
     assert response.status == 201
     assert response.json() == {}


### PR DESCRIPTION
This adds a fake turn server, that pretends to accept requests from Turn with a random delay.

It also adds instructions on how to use that, combined with an existing bot, to stress test and benchmark the connector along with the bot.